### PR TITLE
Support imports

### DIFF
--- a/declarations/avsc.d.ts
+++ b/declarations/avsc.d.ts
@@ -1,3 +1,7 @@
-declare module 'avsc'
+import * as avsc from 'avsc';
 
-// The alternative to this is including "dom" in the tsconfig's `lib` (https://github.com/arangodb/arangojs/issues/577)
+declare module 'avsc' {
+    interface AssembleProtocolError extends Error {
+        path: string;
+    }
+}

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,13 +56,15 @@ const registry = new SchemaRegistry({
 ### Uploading schemas
 
 ```js
-const { readAVSC } = require('@kafkajs/confluent-schema-registry')
+const { readAVSCAsync, avdlToAVSCAsync } = require('@kafkajs/confluent-schema-registry')
 
-// From a avsc file
-await registry.register(readAVSC('path/to/schema.avsc')) // { id: 2 }
+// From an avsc file
+const schema = await readAVSCASync('path/to/schema.avsc')
+await registry.register(schema) // { id: 2 }
 
-// From a avdl file
-await registry.register(avdlToAVSC('path/to/protocol.avdl')) // { id: 3 }
+// From an avdl file
+const schema = await avdlToAVSCAsync('path/to/protocol.avdl')
+await registry.register(schema) // { id: 3 }
 ```
 
 The [compatibility](https://docs.confluent.io/current/schema-registry/avro.html#compatibility-types) of the schema will be whatever the global default is (typically `BACKWARD`).

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -87,3 +87,28 @@ or
   }
 }
 ```
+
+## Imported schemas
+
+Schemas can be imported from other AVDL or AVSC files using [the import declaration](https://avro.apache.org/docs/1.8.2/idl.html#imports). **Note** that this only works using `avdlToAVSCAsync`, not `avdlToAVSC`. Import paths are defined relative to the AVDL file they are imported from. In the following example, `person.avdl` is located next to this AVDL file.
+
+```avdl
+@namespace("com.org.domain.examples")
+protocol MyProtocol {
+  // AVDL files can be imported with "import idl"
+  import idl 'person.avdl';
+
+  // AVSC files can be imported with "import schema"
+  import schema 'place.avsc';
+
+  record Picture {
+    string url;
+  }
+
+  record Event {
+    Picture picture;
+    com.org.domain.examples.Person person;
+    com.org.domain.examples.Place place;
+  }
+}
+```

--- a/fixtures/avdl/import.avdl
+++ b/fixtures/avdl/import.avdl
@@ -1,0 +1,8 @@
+@namespace("com.org.domain.fixtures")
+protocol ImportProto {
+  import idl "simple.avdl";
+
+  record Import {
+    com.org.domain.fixtures.Simple simple;
+  }
+}

--- a/fixtures/avdl/import_multiple_namespaces.avdl
+++ b/fixtures/avdl/import_multiple_namespaces.avdl
@@ -1,0 +1,8 @@
+@namespace("com.org.domain.fixtures")
+protocol ImportMultipleNamespacesProto {
+  import idl "multiple_namespaces.avdl";
+
+  record ImportMultipleNamespaces {
+    com.org.messaging.Metadata metadata;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,2 @@
-export { default as avdlToAVSC } from './avdlToAVSC'
-export { default as readAVSC } from './readAVSC'
+export { avdlToAVSC, avdlToAVSCAsync } from './avdlToAVSC'
+export { readAVSC, readAVSCAsync } from './readAVSC'

--- a/src/utils/readAVSC.ts
+++ b/src/utils/readAVSC.ts
@@ -1,3 +1,14 @@
 import fs from 'fs'
+import { promisify } from 'util'
 
-export default (path: string) => JSON.parse(fs.readFileSync(path, 'utf-8'))
+const readFileAsync = promisify(fs.readFile)
+const ENCODING = 'utf-8'
+
+export function readAVSC(path: string) {
+  return JSON.parse(fs.readFileSync(path, ENCODING))
+}
+
+export async function readAVSCAsync(path: string) {
+  const file = await readFileAsync(path, ENCODING)
+  return JSON.parse(file)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -686,9 +686,9 @@ atob@^2.1.1:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 "avsc@>= 5.4.13 < 6":
-  version "5.4.16"
-  resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.4.16.tgz#ab57863760f69c11ed315a7b8bde95d92f2222e4"
-  integrity sha512-Z85B8ZaEU2PWNPRJYuMSp5Hg7Nw3KPKW47lW/Kus7AcwV7fr6uJG3UckagqIPLydIeO/Cm+yjnJG7g0tliICOg==
+  version "5.4.18"
+  resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.4.18.tgz#8d7f869924d1eb364c68cb5e9807cbd8e28c9c8d"
+  integrity sha512-rQwa/WrpfNm1jEzmRe78EuKvvI9uikZeZL68HqTbbPFTFgZPxExhJESHyqgwlVvWCKlYTwBezR38G1Tjkn+2Zg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This allows you to share types across multiple protocols without having to duplicate them in each file. Imports are relative to the current schema (the paths are essentially just passed to `fs.readFile`), so you could imagine referencing shared types from NPM packages by doing something like `import idl '../../node_modules/@company/schemas/metadata.avdl'`.

The main gist of it is that the async version of `avdlToAVSC` uses `assembleProtocol` instead of `readProtocol`. [This is because `readProtocol` doesn't support imports](https://github.com/mtth/avsc/wiki/API#readprotocolspec-opts).

See the tests or documentation for examples.

I had some problems with vscode not getting the types for `avsc`, as I wanted to augment the module with a type for the error that `assembleProtocol` can give you in the callback. I _think_ it works now, but it was weird.