### PR TITLE
Adding Support for Schema References.

### DIFF
--- a/src/@types.ts
+++ b/src/@types.ts
@@ -6,6 +6,14 @@ export interface Schema {
   namespace: string
 }
 
+export interface SchemaReference {
+  name: string
+  subject: string
+  version: number | string
+}
+
+export type SchemaRef = Omit<SchemaReference, 'name'>
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import avro, { ForSchemaOptions } from 'avsc'
+import avro, { ForSchemaOptions, types } from 'avsc'
 
 import { RawSchema, Schema, SchemaRef } from './@types'
 
@@ -39,7 +39,7 @@ export default class Cache {
   setSchema = (
     registryId: number,
     schema: RawSchema,
-    logicalTypesExtra: Record<string, Schema> = {},
+    logicalTypesExtra: Record<string, new () => types.LogicalType> = {},
   ) => {
     // @ts-ignore TODO: Fix typings for Schema...
     this.schemasByRegistryId[registryId] = avro.Type.forSchema(schema, {
@@ -50,12 +50,12 @@ export default class Cache {
           : (attr, opts) => {
               if (typeof attr == 'string') {
                 if (attr in opts.logicalTypes) {
-                  return opts.logicalTypes[attr]
+                  return (opts.logicalTypes[attr] as unknown) as avro.Type
                 }
                 // if we map this as 'namespace.type'.
                 const qualifiedName = `${opts.namespace}.${attr}`
                 if (qualifiedName in opts.logicalTypes) {
-                  return opts.logicalTypes[qualifiedName]
+                  return (opts.logicalTypes[qualifiedName] as unknown) as avro.Type
                 }
               }
             },

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,16 +1,29 @@
 import avro, { ForSchemaOptions } from 'avsc'
 
-import { Schema } from './@types'
+import { Schema, SchemaRef } from './@types'
 
 export default class Cache {
   registryIdBySubject: { [key: string]: number }
   schemasByRegistryId: { [key: string]: Schema }
+  registryIdBySchemaRef: { [key: string]: number }
   forSchemaOptions?: Partial<ForSchemaOptions>
 
   constructor(forSchemaOptions?: Partial<ForSchemaOptions>) {
     this.registryIdBySubject = {}
     this.schemasByRegistryId = {}
+    this.registryIdBySchemaRef = {}
     this.forSchemaOptions = forSchemaOptions
+  }
+
+  private schemaKeyGen = ({ subject, version }: SchemaRef): string => `${subject}:${version}`
+
+  getRegistryIdBySchemaRef = (schema: SchemaRef): number =>
+    this.registryIdBySchemaRef[this.schemaKeyGen(schema)]
+
+  setRegistryIdBySchemaRef = (schema: SchemaRef, registryId: number) => {
+    this.registryIdBySchemaRef[this.schemaKeyGen(schema)] = registryId
+
+    return this.registryIdBySchemaRef[this.schemaKeyGen(schema)]
   }
 
   getLatestRegistryId = (subject: string): number | undefined => this.registryIdBySubject[subject]
@@ -23,9 +36,34 @@ export default class Cache {
 
   getSchema = (registryId: number): Schema => this.schemasByRegistryId[registryId]
 
-  setSchema = (registryId: number, schema: Schema) => {
+  setSchema = (
+    registryId: number,
+    schema: Schema,
+    logicalTypesExtra: Record<string, Schema> = {},
+  ) => {
     // @ts-ignore TODO: Fix typings for Schema...
-    this.schemasByRegistryId[registryId] = avro.Type.forSchema(schema, this.forSchemaOptions)
+    this.schemasByRegistryId[registryId] = avro.Type.forSchema(schema, {
+      ...this.forSchemaOptions,
+      typeHook:
+        typeof this.forSchemaOptions?.typeHook === 'function'
+          ? this.forSchemaOptions?.typeHook
+          : (attr, opts) => {
+              if (typeof attr == 'string') {
+                if (attr in opts.logicalTypes) {
+                  return opts.logicalTypes[attr]
+                }
+                // if we map this as 'namespace.type'.
+                const qualifiedName = `${opts.namespace}.${attr}`
+                if (qualifiedName in opts.logicalTypes) {
+                  return opts.logicalTypes[qualifiedName]
+                }
+              }
+            },
+      logicalTypes: {
+        ...this.forSchemaOptions?.logicalTypes,
+        ...logicalTypesExtra,
+      },
+    })
 
     return this.schemasByRegistryId[registryId]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,9 +2668,9 @@ lodash.sortby@^4.7.0:
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lolex@^5.0.0:
   version "5.1.2"


### PR DESCRIPTION
Namaste Team

In this PR: 
- I am adding support for `SchemaReferences` using a combination of `typeHook` and `logicalType`
- This seems to work in out internal testing, but I'll need to figure out how to write unit tests for this.
- This issue is being talked in `avsc`: https://github.com/mtth/avsc/issues/309 but they will not have a solution unless they would like to make api calls to the registry.