### PR TITLE
Feature/schema references

### DIFF
--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -20,12 +20,15 @@ import {
   ConfluentSubject,
   SchemaRegistryAPIClientOptions,
   AvroConfluentSchema,
+  ProtocolOptions,
+  LegacyOptions
 } from './@types'
 import {
   helperTypeFromSchemaType,
   schemaTypeFromString,
   schemaFromConfluentSchema,
 } from './schemaTypeResolver'
+import { Type } from 'avsc/types'
 
 interface RegisteredSchema {
   id: number
@@ -34,7 +37,14 @@ interface RegisteredSchema {
 interface Opts {
   compatibility?: COMPATIBILITY
   separator?: string
+  subject: string,
+  referencedSchemaIds?: number[]
+}
+
+interface Reference {
+  name: string
   subject: string
+  version: number
 }
 
 const DEFAULT_OPTS = {
@@ -97,12 +107,23 @@ export default class SchemaRegistry {
     schema: RawAvroSchema | ConfluentSchema,
     userOpts?: Opts,
   ): Promise<RegisteredSchema> {
-    const { compatibility, separator } = { ...DEFAULT_OPTS, ...userOpts }
+    const { compatibility, separator, referencedSchemaIds } = { ...DEFAULT_OPTS, ...userOpts }
+    let opts = this.options;
+
+    if (referencedSchemaIds) {
+      const referenceSchemas = Object.assign({}, ...await Promise.all(referencedSchemaIds.map(async (id) => {
+        const referencedSchema = await this.getSchema(id) as AvroSchema
+        return { [referencedSchema.name]: referencedSchema }
+      })))
+
+      opts = this.populateRegistryWithReferenceSchemas(referenceSchemas)
+    }
 
     const confluentSchema: ConfluentSchema = this.getConfluentSchema(schema)
 
     const helper = helperTypeFromSchemaType(confluentSchema.type)
-    const schemaInstance = schemaFromConfluentSchema(confluentSchema, this.options)
+    const schemaInstance = schemaFromConfluentSchema(confluentSchema, opts)
+    // const schemaInstance = schemaFromConfluentSchema(confluentSchema, this.options, referenceSchemas)
     helper.validate(schemaInstance)
 
     let subject: ConfluentSubject
@@ -138,6 +159,7 @@ export default class SchemaRegistry {
       body: {
         schemaType: confluentSchema.type,
         schema: confluentSchema.schema,
+        // ...(referencedSchemas && { references: referencedSchemas })
       },
     })
 
@@ -150,13 +172,26 @@ export default class SchemaRegistry {
 
   public async getSchema(registryId: number): Promise<Schema | AvroSchema> {
     const schema = this.cache.getSchema(registryId)
+    let opts = this.options
 
     if (schema) {
       return schema
     }
 
     const response = await this.getSchemaOriginRequest(registryId)
-    const foundSchema: { schema: string; schemaType: string } = response.data()
+    const foundSchema: { schema: string; schemaType: string; references?: Reference[]; } = response.data()
+
+    if (foundSchema.references) {
+      const referenceSchemas = Object.assign({}, ...await Promise.all(foundSchema.references.map(async (reference) => {
+        const referenceSchemaId = await this.getRegistryId(reference.subject, reference.version)
+        // @ts-ignore TODO: Fix typings for Schema...
+        const referenceType: Type = await this.getSchema(referenceSchemaId)
+        return { [reference.subject]: referenceType }
+      })));
+
+      opts = this.populateRegistryWithReferenceSchemas(referenceSchemas);
+    }
+
     const rawSchema = foundSchema.schema
     const schemaType = schemaTypeFromString(foundSchema.schemaType)
 
@@ -168,8 +203,22 @@ export default class SchemaRegistry {
       type: schemaType,
       schema: rawSchema,
     }
-    const schemaInstance = schemaFromConfluentSchema(confluentSchema, this.options)
+    const schemaInstance = schemaFromConfluentSchema(confluentSchema, opts)
     return this.cache.setSchema(registryId, schemaInstance)
+  }
+
+  private populateRegistryWithReferenceSchemas(referenceSchemas: { [x: string]: Type }) {
+      const schemaOptions = (this.options as LegacyOptions)?.forSchemaOptions || (this.options as ProtocolOptions)?.[SchemaType.AVRO]
+
+      return {
+        [SchemaType.AVRO]: {
+          ...schemaOptions,
+          registry: {
+            ...schemaOptions?.registry,
+            ...referenceSchemas
+          }
+        }
+      }
   }
 
   public async encode(registryId: number, payload: any): Promise<Buffer> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,7 @@ export interface SchemaRegistryAPIClientArgs {
 export type SchemaRegistryAPIClient = Client<{
   Schema: {
     find: (_: any) => any
+    versions: (_: any) => any
   }
   Subject: {
     all: (_: any) => any
@@ -65,6 +66,10 @@ export default ({
           method: 'get',
           path: '/schemas/ids/{id}',
         },
+        versions: {
+          method: 'get',
+          path: '/schemas/ids/{id}/versions'
+        }
       },
       Subject: {
         all: {


### PR DESCRIPTION
Hello!

I am looking to add in functionality for schema references in this pull request. Specifically, I noticed a PR has already been created for this, [PR#92](https://github.com/kafkajs/confluent-schema-registry/pull/92), but seems to have lost traction for getting merged in. Although there are still a few changes I plan to make to this pull request before considering it ready to be pulled in, I wanted to get a pulse check into the likelihood of this PR getting merged, especially as compared to PR#92. Things I still am looking to change include:
- Caching some of the API calls I have added into the register function.
- Write integration tests.
- Overall code cleanup.

This PR is intended to only add schema references to AVRO. Protobuf namely seems to be giving me issues while encoding nested structures, and seems to not be in a state of feature parity with AVRO. Likely, more fixes will be need to be addressed before including schema reference functionality to other schema types.

Here is an example of how client code would look like while interfacing with these changes:
```javascript
const { SchemaRegistry, SchemaType } = require('@kafkajs/confluent-schema-registry');
const dotenv = require('dotenv');
dotenv.config();

const schemaRegistry = new SchemaRegistry({ host: process.env.REGISTRY_HOST });

const cookieSchema = JSON.stringify({
    type: "record",
    name: "Cookie",
    namespace: "com.food",
    fields: [
        { name: "name", type: "string" },
        { name: "calories", type: "int" }
    ]
});

const cakeSchema = JSON.stringify({
    type: "record",
    name: "Cake",
    namespace: "com.food",
    fields: [
        { name: "name", type: "string" },
        { name: "size", type: "int" }
    ]
});

const genericFoodSchema = JSON.stringify({
    type: 'record',
    name: 'GenericFood',
    namespace: 'com.food',
    fields: [
        { name: 'food', type: ['Cookie', 'Cake'] }
    ]
});

const main = async () => {
    const { id: cookieId } = await schemaRegistry.register({
        type: SchemaType.AVRO,
        schema: cookieSchema
    });

    const { id: cakeId } = await schemaRegistry.register({
        type: SchemaType.AVRO,
        schema: cakeSchema
    });

    const { id: genericFoodId } = await schemaRegistry.register({
        type: SchemaType.AVRO,
        schema: genericFoodSchema
    }, {
        referenceSchemaIds: [
            cookieId,
            cakeId
        ]
    });

    const encodedPayload = await schemaRegistry.encode(genericFoodId, {
        food: {
            'com.food.Cookie': {
                name :'BigOlCookie',
                calories: 1000
            }
        }
    });

    const decodedPayload = await schemaRegistry.decode(encodedPayload);
    console.log('calories', decodedPayload.food['com.food.Cookie'].calories);
};

main();

```