### PR TITLE
Adding support for the ajv-formats plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "ajv": "^7.1.0",
-    "ajv-formats": "^1.5.1",
     "avsc": ">= 5.4.13 < 6",
     "mappersmith": ">= 2.30.1 < 3",
     "protobufjs": "^6.10.1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "ajv": "^7.1.0",
+    "ajv-formats": "^1.5.1",
     "avsc": ">= 5.4.13 < 6",
     "mappersmith": ">= 2.30.1 < 3",
     "protobufjs": "^6.10.1"

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -14,7 +14,7 @@ export interface SchemaHelper {
 }
 
 export type AvroOptions = Partial<ForSchemaOptions>
-export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & { addAjvFormats: boolean }
+export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & { ajvInstance?: Ajv }
 export type ProtoOptions = { messageName: string }
 
 export interface LegacyOptions {

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -14,7 +14,7 @@ export interface SchemaHelper {
 }
 
 export type AvroOptions = Partial<ForSchemaOptions>
-export type JsonOptions = ConstructorParameters<typeof Ajv>[0]
+export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & { addAjvFormats: boolean }
 export type ProtoOptions = { messageName: string }
 
 export interface LegacyOptions {

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -1,5 +1,6 @@
 import { Schema, JsonOptions, ConfluentSchema } from './@types'
 import Ajv, { DefinedError, ValidateFunction } from 'ajv'
+import addFormats from 'ajv-formats'
 import { ConfluentSchemaRegistryValidationError } from './errors'
 
 export default class JsonSchema implements Schema {
@@ -11,6 +12,9 @@ export default class JsonSchema implements Schema {
 
   private getJsonSchema(schema: ConfluentSchema, opts?: JsonOptions) {
     const ajv = new Ajv(opts)
+    if (opts?.addAjvFormats) {
+      addFormats(ajv)
+    }
     const validate = ajv.compile(JSON.parse(schema.schema))
     return validate
   }

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -1,6 +1,5 @@
 import { Schema, JsonOptions, ConfluentSchema } from './@types'
 import Ajv, { DefinedError, ValidateFunction } from 'ajv'
-import addFormats from 'ajv-formats'
 import { ConfluentSchemaRegistryValidationError } from './errors'
 
 export default class JsonSchema implements Schema {
@@ -11,10 +10,7 @@ export default class JsonSchema implements Schema {
   }
 
   private getJsonSchema(schema: ConfluentSchema, opts?: JsonOptions) {
-    const ajv = new Ajv(opts)
-    if (opts?.addAjvFormats) {
-      addFormats(ajv)
-    }
+    const ajv = opts?.ajvInstance ?? new Ajv(opts)
     const validate = ajv.compile(JSON.parse(schema.schema))
     return validate
   }

--- a/src/schemaTypeResolver.ts
+++ b/src/schemaTypeResolver.ts
@@ -81,7 +81,7 @@ export const schemaFromConfluentSchema = (
         break
       }
       case SchemaType.JSON: {
-        const opts: JsonOptions = (options as ProtocolOptions)?.[SchemaType.JSON]
+        const opts: JsonOptions | undefined = (options as ProtocolOptions)?.[SchemaType.JSON]
         schema = new JsonSchema(confluentSchema, opts)
         break
       }


### PR DESCRIPTION
Hello,

the base ajv schema validator has no support for the built-in JSON Schema formats like `date-time` `email` or `uri`. This requires adding the `ajv-formats` plugin.

This PR adds the `ajv-formats` plugin along with an additional options parameter for including it in the schema validation.