### PR TITLE
WIP: Investigate Protocol Buffer references (imports) 

### DIFF
--- a/bin/avdlToAVSC.sh
+++ b/bin/avdlToAVSC.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 avdl_path=$1
 avsc_name=$2
 

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -11,6 +11,7 @@ export enum SchemaType {
 export interface SchemaHelper {
   validate(schema: Schema): void
   getSubject(confluentSchema: ConfluentSchema, schema: Schema, separator: string): ConfluentSubject
+  referencedSchemas(schema: string): Promise<string[]>
 }
 
 export type AvroOptions = Partial<ForSchemaOptions>

--- a/src/AvroHelper.ts
+++ b/src/AvroHelper.ts
@@ -44,4 +44,11 @@ export default class AvroHelper implements SchemaHelper {
     }
     return subject
   }
+
+  public async referencedSchemas(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _schema: string,
+  ): Promise<string[]> {
+    return []
+  }
 }

--- a/src/JsonHelper.ts
+++ b/src/JsonHelper.ts
@@ -14,4 +14,11 @@ export default class JsonHelper implements SchemaHelper {
   ): ConfluentSubject {
     throw new ConfluentSchemaRegistryError('not implemented yet')
   }
+
+  public async referencedSchemas(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _schema: string,
+  ): Promise<string[]> {
+    return []
+  }
 }

--- a/src/ProtoHelper.ts
+++ b/src/ProtoHelper.ts
@@ -1,17 +1,37 @@
-// @ts-nocheck
 import { Schema, SchemaHelper, ConfluentSubject, ConfluentSchema } from './@types'
 import { ConfluentSchemaRegistryError } from './errors'
+import { parse } from 'protobufjs'
 
 export default class ProtoHelper implements SchemaHelper {
-  public validate(schema: Schema): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public validate(_schema: Schema): void {
     return
   }
 
   public getSubject(
-    confluentSchema: ConfluentSchema,
-    schema: Schema,
-    separator: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _confluentSchema: ConfluentSchema,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _schema: Schema,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _separator: string,
   ): ConfluentSubject {
     throw new ConfluentSchemaRegistryError('not implemented yet')
+  }
+
+  /**
+   * Get the schemas referenced by the provided schema.
+   *
+   * @param schema The schema to find references for
+   * @param fetchSchema A helper function that can fetch the schema definition given
+   *     the import path (reference name)
+   *
+   * @returns A map from Schema Registry subject to ConfluentSchema. The map describes
+   *     each imported/referenced schema that is used by the given schema.
+   */
+  public async referencedSchemas(schema: string): Promise<string[]> {
+    const parsed = parse(schema)
+    const out: string[] = []
+    return out.concat(parsed.imports || []).concat(parsed.weakImports || [])
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,7 @@ export interface SchemaRegistryAPIClientArgs {
 export type SchemaRegistryAPIClient = Client<{
   Schema: {
     find: (_: any) => any
+    versions: (_: any) => any
   }
   Subject: {
     all: (_: any) => any
@@ -64,6 +65,10 @@ export default ({
         find: {
           method: 'get',
           path: '/schemas/ids/{id}',
+        },
+        versions: {
+          method: 'get',
+          path: '/schemas/ids/{id}/versions',
         },
       },
       Subject: {


### PR DESCRIPTION
Still TODO:
1. `encode` and `decode` needs to understand references
2. encoded and decoded messages should use and understand message indexes (https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format) 