### PR TITLE
Support reader schema when decoding avro

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -43,4 +43,10 @@ const encodedPayload = await registry.encode(id, payload)
 
 // Decode the payload
 const decodedPayload = await registry.decode(encodedPayload)
+
+// Decode with resolving to a reader schema (avro-only)
+// Note: avsc opts, if needed, should be set to readerSchema
+const avsc = require('avsc')
+const readerSchema = avsc.Type.forSchema(/* schema, opts */)
+const resolvedPayload = await registry.decode(encodedPayload, readerSchema)
 ```

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -43,10 +43,7 @@ export interface RawAvroSchema {
   fields: any[]
 }
 
-export interface AvroSchema extends Schema, RawAvroSchema {
-  createResolver(writerSchema: AvroSchema): Resolver
-  equals(other: Schema): Boolean
-}
+export interface AvroSchema extends Schema, RawAvroSchema {}
 
 export interface ConfluentSubject {
   name: string

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -43,7 +43,10 @@ export interface RawAvroSchema {
   fields: any[]
 }
 
-export interface AvroSchema extends Schema, RawAvroSchema {}
+export interface AvroSchema extends Schema, RawAvroSchema {
+  createResolver(writerSchema: AvroSchema): Resolver
+  equals(other: Schema): Boolean
+}
 
 export interface ConfluentSubject {
   name: string

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -1,15 +1,21 @@
-import {v4 as uuid} from 'uuid'
+import { Type } from 'avsc'
+import { v4 as uuid } from 'uuid'
 
 import SchemaRegistry from './SchemaRegistry'
-import {AvroSchema, ConfluentSchema, ConfluentSubject, SchemaType,} from './@types'
-import API, {SchemaRegistryAPIClient} from './api'
-import {COMPATIBILITY, DEFAULT_API_CLIENT_ID} from './constants'
+import {
+  ConfluentSubject,
+  ConfluentSchema,
+  SchemaType,
+  AvroConfluentSchema,
+  JsonConfluentSchema,
+} from './@types'
+import API, { SchemaRegistryAPIClient } from './api'
+import { COMPATIBILITY, DEFAULT_API_CLIENT_ID } from './constants'
 import encodedAnotherPersonV2Avro from '../fixtures/avro/encodedAnotherPersonV2'
 import encodedAnotherPersonV2Json from '../fixtures/json/encodedAnotherPersonV2'
 import encodedAnotherPersonV2Proto from '../fixtures/proto/encodedAnotherPersonV2'
 import encodedNestedV2Proto from '../fixtures/proto/encodedNestedV2'
 import wrongMagicByte from '../fixtures/wrongMagicByte'
-import {Type} from "avsc";
 
 const REGISTRY_HOST = 'http://localhost:8982'
 const schemaRegistryAPIClientArgs = { host: REGISTRY_HOST }
@@ -362,10 +368,10 @@ describe('SchemaRegistry - new Api', () => {
         (type == SchemaType.AVRO ? it : it.skip)(
           'uses reader schema if specified (avro-only)', async () => {
             const writerBuffer = Buffer.from(await schemaRegistry.encode(registryId, payload))
-            const readerSchema = Type.forSchema(JSON.parse(schemaStringsByType[type].v2)) as any as AvroSchema
+            const readerSchema = Type.forSchema(JSON.parse(schemaStringsByType[type].v2))
             await expect(schemaRegistry.decode(writerBuffer, readerSchema)).resolves.toHaveProperty(
-                'city',
-                'Stockholm'
+              'city',
+              'Stockholm'
             )
           })
 

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -1,20 +1,15 @@
-import { v4 as uuid } from 'uuid'
+import {v4 as uuid} from 'uuid'
 
 import SchemaRegistry from './SchemaRegistry'
-import {
-  ConfluentSubject,
-  ConfluentSchema,
-  SchemaType,
-  AvroConfluentSchema,
-  JsonConfluentSchema,
-} from './@types'
-import API, { SchemaRegistryAPIClient } from './api'
-import { COMPATIBILITY, DEFAULT_API_CLIENT_ID } from './constants'
+import {AvroSchema, ConfluentSchema, ConfluentSubject, SchemaType,} from './@types'
+import API, {SchemaRegistryAPIClient} from './api'
+import {COMPATIBILITY, DEFAULT_API_CLIENT_ID} from './constants'
 import encodedAnotherPersonV2Avro from '../fixtures/avro/encodedAnotherPersonV2'
 import encodedAnotherPersonV2Json from '../fixtures/json/encodedAnotherPersonV2'
 import encodedAnotherPersonV2Proto from '../fixtures/proto/encodedAnotherPersonV2'
 import encodedNestedV2Proto from '../fixtures/proto/encodedNestedV2'
 import wrongMagicByte from '../fixtures/wrongMagicByte'
+import {Type} from "avsc";
 
 const REGISTRY_HOST = 'http://localhost:8982'
 const schemaRegistryAPIClientArgs = { host: REGISTRY_HOST }
@@ -362,7 +357,17 @@ describe('SchemaRegistry - new Api', () => {
           await schemaRegistry.decode(buffer)
 
           expect(schemaRegistry.cache.getSchema(registryId)).toBeTruthy()
-        })
+        });
+
+        (type == SchemaType.AVRO ? it : it.skip)(
+          'uses reader schema if specified (avro-only)', async () => {
+            const writerBuffer = Buffer.from(await schemaRegistry.encode(registryId, payload))
+            const readerSchema = Type.forSchema(JSON.parse(schemaStringsByType[type].v2)) as any as AvroSchema
+            await expect(schemaRegistry.decode(writerBuffer, readerSchema)).resolves.toHaveProperty(
+                'city',
+                'Stockholm'
+            )
+          })
 
         it('creates a single origin request for a schema cache-miss', async () => {
           const buffer = Buffer.from(await schemaRegistry.encode(registryId, payload))

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -200,7 +200,7 @@ export default class SchemaRegistry {
     return paths
   }
 
-  public async decode(buffer: Buffer): Promise<any> {
+  public async decode(buffer: Buffer, readerSchema?: AvroSchema): Promise<any> {
     if (!Buffer.isBuffer(buffer)) {
       throw new ConfluentSchemaRegistryArgumentError('Invalid buffer')
     }
@@ -214,8 +214,21 @@ export default class SchemaRegistry {
       )
     }
 
-    const schema = await this.getSchema(registryId)
-    return schema.fromBuffer(payload)
+    const writerSchema = await this.getSchema(registryId)
+    if (readerSchema) {
+      if (readerSchema.equals(writerSchema)){
+        /* Even when schemas are considered equal by `avsc`,
+         * they still aren't interchangeable:
+         * provided `readerSchema` may have different `opts` (e.g. logicalTypes / unionWrap flags)
+         * see https://github.com/mtth/avsc/issues/362 */
+        return readerSchema.fromBuffer(payload)
+      } else {
+        // decode using a resolver from writer type into reader type
+        return readerSchema.fromBuffer(payload, readerSchema.createResolver(writerSchema as AvroSchema))
+      }
+    } else {
+      return writerSchema.fromBuffer(payload)
+    }
   }
 
   public async getRegistryId(subject: string, version: number | string): Promise<number> {

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -1,3 +1,4 @@
+import { Type } from 'avsc'
 import { Response } from 'mappersmith'
 
 import { encode, MAGIC_BYTE } from './wireEncoder'
@@ -200,7 +201,7 @@ export default class SchemaRegistry {
     return paths
   }
 
-  public async decode(buffer: Buffer, readerSchema?: AvroSchema): Promise<any> {
+  public async decode(buffer: Buffer, readerSchema?: Type): Promise<any> {
     if (!Buffer.isBuffer(buffer)) {
       throw new ConfluentSchemaRegistryArgumentError('Invalid buffer')
     }
@@ -216,7 +217,7 @@ export default class SchemaRegistry {
 
     const writerSchema = await this.getSchema(registryId)
     if (readerSchema) {
-      if (readerSchema.equals(writerSchema)){
+      if (readerSchema.equals(writerSchema as Type)){
         /* Even when schemas are considered equal by `avsc`,
          * they still aren't interchangeable:
          * provided `readerSchema` may have different `opts` (e.g. logicalTypes / unionWrap flags)
@@ -224,7 +225,7 @@ export default class SchemaRegistry {
         return readerSchema.fromBuffer(payload)
       } else {
         // decode using a resolver from writer type into reader type
-        return readerSchema.fromBuffer(payload, readerSchema.createResolver(writerSchema as AvroSchema))
+        return readerSchema.fromBuffer(payload, readerSchema.createResolver(writerSchema as Type))
       }
     } else {
       return writerSchema.fromBuffer(payload)


### PR DESCRIPTION
## Problem
The resolution between different reader & writer schemas is a key concept in Avro format.
[The specification](https://avro.apache.org/docs/current/spec.html#Schema+Resolution) is already implemented by [avsc Resolver](https://github.com/mtth/avsc/wiki/API#typecreateresolverwritertype)

While `confluent-schema-registry` relies on `avsc`, it doesn't support specifying a reader schema when decoding.

Also, `avsc` library have `opts` (e.g. logicalTypes, union wrapping, etc) configured on Type (schema-representing object) level, but `confluent-schema-registry` lacks an ability to override opts while reading, they're global.

## Solution
Pass an optional `avsc` reader schema to `decode`

## Things done:

- Added an optional argument for reader schema in `.decode`. The method behaves as before when it's not provided.
  An extra arg involves resolver when reader and writer schemas are different.
  It also allows to customize `avsc` opts per reader schema instead of registry globals
- Added a unit test that resolution takes place when reader schema is provided



