### PR TITLE
Don't include the schemaType field in API requests when type is Avro

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
   - job: lint
     displayName: Lint
     pool:
-      vmImage: 'Ubuntu 16.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - task: NodeTool@0
         inputs:
@@ -34,7 +34,7 @@ jobs:
   - job: build
     displayName: Build
     pool:
-      vmImage: 'Ubuntu 16.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - task: NodeTool@0
         inputs:
@@ -48,7 +48,7 @@ jobs:
     displayName: Tests
     dependsOn: lint
     pool:
-      vmImage: 'Ubuntu 16.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - task: NodeTool@0
         inputs:
@@ -68,7 +68,7 @@ jobs:
       - build
       - unit_tests
     pool:
-      vmImage: 'Ubuntu 16.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - task: NodeTool@0
         inputs:
@@ -95,7 +95,7 @@ jobs:
       - lint
       - unit_tests
     pool:
-      vmImage: 'Ubuntu 16.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - task: NodeTool@0
         inputs:

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -136,7 +136,7 @@ export default class SchemaRegistry {
     const response = await this.api.Subject.register({
       subject: subject.name,
       body: {
-        schemaType: confluentSchema.type,
+        schemaType: confluentSchema.type === SchemaType.AVRO ? undefined : confluentSchema.type,
         schema: confluentSchema.schema,
       },
     })
@@ -234,7 +234,7 @@ export default class SchemaRegistry {
       const response = await this.api.Subject.registered({
         subject,
         body: {
-          schemaType: confluentSchema.type,
+          schemaType: confluentSchema.type === SchemaType.AVRO ? undefined : confluentSchema.schema,
           schema: confluentSchema.schema,
         },
       })

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -234,7 +234,7 @@ export default class SchemaRegistry {
       const response = await this.api.Subject.registered({
         subject,
         body: {
-          schemaType: confluentSchema.type === SchemaType.AVRO ? undefined : confluentSchema.schema,
+          schemaType: confluentSchema.type === SchemaType.AVRO ? undefined : confluentSchema.type,
           schema: confluentSchema.schema,
         },
       })


### PR DESCRIPTION
Confluent Schema Registry made a backwards incompatible API change without changing the version of the API, so now we have to hack around this. Same thing that was done for the Java client in https://github.com/confluentinc/schema-registry/pull/1288

Fixes #155