### PR TITLE
Handle Ajv backwards incompatible changes between 7 and 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^2.1.0",
     "@typescript-eslint/parser": "^2.1.0",
     "@typescript-eslint/typescript-estree": "^2.1.0",
+    "ajv8": "npm:ajv",
     "dockest": "^2.1.0",
     "eslint": "^6.3.0",
     "eslint-config-prettier": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^2.1.0",
     "@typescript-eslint/parser": "^2.1.0",
     "@typescript-eslint/typescript-estree": "^2.1.0",
-    "ajv8": "npm:ajv",
+    "ajv8": "npm:ajv@^8.6.3",
     "dockest": "^2.1.0",
     "eslint": "^6.3.0",
     "eslint-config-prettier": "^6.1.0",

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -14,7 +14,9 @@ export interface SchemaHelper {
 }
 
 export type AvroOptions = Partial<ForSchemaOptions>
-export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & { ajvInstance?: Ajv }
+export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & {
+  ajvInstance?: Pick<Ajv, 'compile'>
+}
 export type ProtoOptions = { messageName: string }
 
 export interface LegacyOptions {

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -1,4 +1,5 @@
 import { Resolver, ForSchemaOptions } from 'avsc'
+import { ValidateFunction } from './JsonSchema'
 import Ajv from 'ajv'
 
 export enum SchemaType {
@@ -15,7 +16,9 @@ export interface SchemaHelper {
 
 export type AvroOptions = Partial<ForSchemaOptions>
 export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & {
-  ajvInstance?: Pick<Ajv, 'compile'>
+  ajvInstance?: {
+    compile: (schema: any) => ValidateFunction
+  }
 }
 export type ProtoOptions = { messageName: string }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,8 +711,8 @@ acorn@^7.1.0, acorn@^7.1.1:
 
 "ajv8@npm:ajv@^8.6.3":
   version "8.6.3"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
-  integrity sha1-EaZlJ3Ydw+mjhF6nddLTwEFOh2Q=
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -1320,8 +1320,8 @@ diff@^4.0.1:
 
 dockest@^2.1.0:
   version "2.1.0"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/dockest/-/dockest-2.1.0.tgz#efbeaca7bb6078b9bb0a431a050cdefc5b50f07e"
-  integrity sha1-776sp7tgeLm7CkMaBQze/FtQ8H4=
+  resolved "https://registry.yarnpkg.com/dockest/-/dockest-2.1.0.tgz#efbeaca7bb6078b9bb0a431a050cdefc5b50f07e"
+  integrity sha512-cEudMXrP9Sl1obedYDEyXoKSePGsmbT8750W2D1/W19szr+EbSlEpaRp3tIl5q8oeZ6UxFnfZjXzD+4nDrVhZw==
   dependencies:
     chalk "^3.0.0"
     execa "^4.0.0"
@@ -1585,8 +1585,8 @@ execa@^3.2.0:
 
 execa@^4.0.0:
   version "4.1.0"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
-  integrity sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
   dependencies:
     cross-spawn "^7.0.0"
     get-stream "^5.0.0"
@@ -1782,8 +1782,8 @@ form-data@~2.3.2:
 
 fp-ts@^2.8.3:
   version "2.11.5"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/fp-ts/-/fp-ts-2.11.5.tgz#97cceb26655b1452d7088d6fb0864f84cceffbe4"
-  integrity sha1-l8zrJmVbFFLXCI1vsIZPhMzv++Q=
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.5.tgz#97cceb26655b1452d7088d6fb0864f84cceffbe4"
+  integrity sha512-OqlwJq1BdpB83BZXTqI+dNcA6uYk6qk4u9Cgnt64Y+XS7dwdbp/mobx8S2KXf2AXH+scNmA/UVK3SEFHR3vHZA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -2045,8 +2045,8 @@ inquirer@^7.0.0:
 
 io-ts@^2.2.10:
   version "2.2.16"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
-  integrity sha1-WX3/oD2xkT/DGMnG32kxy07YCLI=
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
+  integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -2113,8 +2113,8 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
 
 is-docker@^2.0.0:
   version "2.2.1"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
-  integrity sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -3453,8 +3453,8 @@ rxjs@^6.5.3:
 
 rxjs@^6.5.4:
   version "6.6.7"
-  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,16 @@ acorn@^7.1.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
+"ajv8@npm:ajv":
+  version "8.6.3"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha1-EaZlJ3Ydw+mjhF6nddLTwEFOh2Q=
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
@@ -1308,13 +1318,18 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dockest@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/dockest/-/dockest-1.0.4.tgz#0da0fb44aeba1d9923aa72a6f43fe6aea1174296"
-  integrity sha512-fHAU1z9CkMDHeoJo0oxg0sK1BYc3tANmGKAm7tPY/OpVV3DUVCSDwnpqtq7H3/I7tKvII5xF44hE1iSC+qNvnA==
+dockest@^2.1.0:
+  version "2.1.0"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/dockest/-/dockest-2.1.0.tgz#efbeaca7bb6078b9bb0a431a050cdefc5b50f07e"
+  integrity sha1-776sp7tgeLm7CkMaBQze/FtQ8H4=
   dependencies:
-    execa "^2.0.4"
+    chalk "^3.0.0"
+    execa "^4.0.0"
+    fp-ts "^2.8.3"
+    io-ts "^2.2.10"
+    is-docker "^2.0.0"
     js-yaml "^3.13.1"
+    rxjs "^6.5.4"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -1568,6 +1583,21 @@ execa@^3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^4.0.0:
+  version "4.1.0"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -1749,6 +1779,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+fp-ts@^2.8.3:
+  version "2.11.5"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/fp-ts/-/fp-ts-2.11.5.tgz#97cceb26655b1452d7088d6fb0864f84cceffbe4"
+  integrity sha1-l8zrJmVbFFLXCI1vsIZPhMzv++Q=
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -2008,6 +2043,11 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+io-ts@^2.2.10:
+  version "2.2.16"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
+  integrity sha1-WX3/oD2xkT/DGMnG32kxy07YCLI=
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -2070,6 +2110,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
+
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -3403,6 +3448,13 @@ rxjs@^6.5.3:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.4:
+  version "6.6.7"
+  resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=
   dependencies:
     tslib "^1.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,7 +709,7 @@ acorn@^7.1.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
-"ajv8@npm:ajv":
+"ajv8@npm:ajv@^8.6.3":
   version "8.6.3"
   resolved "https://artifactory.klarna.net/artifactory/api/npm/v-npm-production/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
   integrity sha1-EaZlJ3Ydw+mjhF6nddLTwEFOh2Q=


### PR DESCRIPTION
Since v3.1.0 we allow passing an Ajv instance in the constructor parameters. However, because we require it to be an instance of `Ajv`, and Ajv made backwards incompatible changes in version 8, it means that you cannot use that version with this package.

Our interface towards Ajv is actually quite small. We only ever use the `compile` method and the error type that we get back. The error type unfortunately had some backwards incompatible changes that affected us, so I had to write a small compatibility shim to construct our error from either version.