### PR TITLE
Update usage docs with working link to Ajv options page

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -275,7 +275,7 @@ const options = {
 
 #### JSON Schema
 
-The JSON Schema schema type options are passed to the [Ajv constructor](https://ajv.js.org/docs/api.html#options).
+The JSON Schema schema type options are passed to the [Ajv constructor](https://ajv.js.org/options.html).
 For example:
 
 ```ts


### PR DESCRIPTION
Existing link to Ajv options page - https://ajv.js.org/docs/api.html#options points to a 404 page.