### PR TITLE
Support reader schema when decoding avro

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -43,10 +43,4 @@ const encodedPayload = await registry.encode(id, payload)
 
 // Decode the payload
 const decodedPayload = await registry.decode(encodedPayload)
-
-// Decode with resolving to a reader schema (avro-only)
-// Note: avsc opts, if needed, should be set to readerSchema
-const avsc = require('avsc')
-const readerSchema = avsc.Type.forSchema(/* schema, opts */)
-const resolvedPayload = await registry.decode(encodedPayload, readerSchema)
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -43,4 +43,10 @@ const encodedPayload = await registry.encode(id, payload)
 
 // Decode the payload
 const decodedPayload = await registry.decode(encodedPayload)
+
+// Decode with resolving to a reader schema (avro-only)
+// Note: avsc opts, if needed, should be set to readerSchema
+const avsc = require('avsc')
+const readerSchema = avsc.Type.forSchema(/* schema, opts */)
+const resolvedPayload = await registry.decode(encodedPayload, readerSchema)
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -203,8 +203,7 @@ used to encode the message.
 import avro from 'avsc'
 import { readAVSCAsync } from '@kafkajs/confluent-schema-registry'
 
-const rawSchema = await readAVSCAsync('path/to/protocol.avdl')
-const readerSchema = avro.Type.forSchema(rawSchema)
+const readerSchema = await readAVSCAsync('path/to/protocol.avdl')
 
 const payload = await registry.decode(buffer, {
   [SchemaType.AVRO]: { readerSchema }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -188,6 +188,29 @@ const payload = await registry.decode(buffer)
 // { full_name: 'John Doe' }
 ```
 
+`registry.decode` has an optional second `options` argument with options
+specific to each schema type.
+
+### Avro
+
+With Avro you can specify a specific reader schema to use to decode the
+message, rather than using the schema registered in the registry. This can
+be useful if you need a projection that is different from the writer schema,
+or if you want to decode a message with a different version than was
+used to encode the message.
+
+```js
+import avro from 'avsc'
+import { readAVSCAsync } from '@kafkajs/confluent-schema-registry'
+
+const rawSchema = await readAVSCAsync('path/to/protocol.avdl')
+const readerSchema = avro.Type.forSchema(rawSchema)
+
+const payload = await registry.decode(buffer, {
+  [SchemaType.AVRO]: { readerSchema }
+})
+```
+
 ## Configuration
 
 ### Retry

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -1,4 +1,4 @@
-import { Resolver, ForSchemaOptions } from 'avsc'
+import { Resolver, ForSchemaOptions, Type } from 'avsc'
 import { ValidateFunction } from './JsonSchema'
 import Ajv from 'ajv'
 
@@ -48,7 +48,10 @@ export interface RawAvroSchema {
   fields: any[]
 }
 
-export interface AvroSchema extends Schema, RawAvroSchema {}
+export interface AvroSchema
+  extends Schema,
+    RawAvroSchema,
+    Pick<Type, 'equals' | 'createResolver'> {}
 
 export interface ConfluentSubject {
   name: string
@@ -56,7 +59,7 @@ export interface ConfluentSubject {
 
 export interface AvroConfluentSchema {
   type: SchemaType.AVRO
-  schema: string
+  schema: string | RawAvroSchema
 }
 
 export interface ProtoConfluentSchema {

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -48,7 +48,10 @@ export interface RawAvroSchema {
   fields: any[]
 }
 
-export interface AvroSchema extends Schema, RawAvroSchema {}
+export interface AvroSchema extends Schema, RawAvroSchema {
+  createResolver(writerSchema: AvroSchema): Resolver
+  equals(other: Schema): Boolean
+}
 
 export interface ConfluentSubject {
   name: string

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -48,10 +48,7 @@ export interface RawAvroSchema {
   fields: any[]
 }
 
-export interface AvroSchema extends Schema, RawAvroSchema {
-  createResolver(writerSchema: AvroSchema): Resolver
-  equals(other: Schema): Boolean
-}
+export interface AvroSchema extends Schema, RawAvroSchema {}
 
 export interface ConfluentSubject {
   name: string

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -1,4 +1,4 @@
-import { Schema, JsonOptions, ConfluentSchema } from './@types'
+import { Schema, JsonOptions, JsonConfluentSchema } from './@types'
 import Ajv from 'ajv'
 import { ConfluentSchemaRegistryValidationError } from './errors'
 
@@ -24,11 +24,11 @@ export interface ValidateFunction {
 export default class JsonSchema implements Schema {
   private validate: ValidateFunction
 
-  constructor(schema: ConfluentSchema, opts?: JsonOptions) {
+  constructor(schema: JsonConfluentSchema, opts?: JsonOptions) {
     this.validate = this.getJsonSchema(schema, opts)
   }
 
-  private getJsonSchema(schema: ConfluentSchema, opts?: JsonOptions) {
+  private getJsonSchema(schema: JsonConfluentSchema, opts?: JsonOptions) {
     const ajv = opts?.ajvInstance ?? new Ajv(opts)
     const validate = ajv.compile(JSON.parse(schema.schema))
     return validate

--- a/src/ProtoSchema.ts
+++ b/src/ProtoSchema.ts
@@ -1,4 +1,4 @@
-import { Schema, ConfluentSchema, ProtoOptions } from './@types'
+import { Schema, ProtoOptions, ProtoConfluentSchema } from './@types'
 import protobuf from 'protobufjs'
 import { IParserResult, ReflectionObject, Namespace, Type } from 'protobufjs/light'
 import {
@@ -9,7 +9,7 @@ import {
 export default class ProtoSchema implements Schema {
   private message: Type
 
-  constructor(schema: ConfluentSchema, opts?: ProtoOptions) {
+  constructor(schema: ProtoConfluentSchema, opts?: ProtoOptions) {
     const parsedMessage = protobuf.parse(schema.schema)
     const root = parsedMessage.root
     this.message = root.lookupType(this.getTypeName(parsedMessage, opts))

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -1,9 +1,16 @@
-import {v4 as uuid} from 'uuid'
+import { Type } from 'avsc'
+import { v4 as uuid } from 'uuid'
 
 import SchemaRegistry from './SchemaRegistry'
-import {AvroSchema, ConfluentSchema, ConfluentSubject, SchemaType,} from './@types'
-import API, {SchemaRegistryAPIClient} from './api'
-import {COMPATIBILITY, DEFAULT_API_CLIENT_ID} from './constants'
+import {
+  ConfluentSubject,
+  ConfluentSchema,
+  SchemaType,
+  AvroConfluentSchema,
+  JsonConfluentSchema,
+} from './@types'
+import API, { SchemaRegistryAPIClient } from './api'
+import { COMPATIBILITY, DEFAULT_API_CLIENT_ID } from './constants'
 import encodedAnotherPersonV2Avro from '../fixtures/avro/encodedAnotherPersonV2'
 import encodedAnotherPersonV2Json from '../fixtures/json/encodedAnotherPersonV2'
 import encodedAnotherPersonV2Proto from '../fixtures/proto/encodedAnotherPersonV2'
@@ -12,7 +19,6 @@ import wrongMagicByte from '../fixtures/wrongMagicByte'
 import Ajv2020 from 'ajv8/dist/2020'
 import Ajv from 'ajv'
 import { ConfluentSchemaRegistryValidationError } from './errors'
-import {Type} from "avsc";
 
 const REGISTRY_HOST = 'http://localhost:8982'
 const schemaRegistryAPIClientArgs = { host: REGISTRY_HOST }
@@ -365,10 +371,10 @@ describe('SchemaRegistry - new Api', () => {
         (type == SchemaType.AVRO ? it : it.skip)(
           'uses reader schema if specified (avro-only)', async () => {
             const writerBuffer = Buffer.from(await schemaRegistry.encode(registryId, payload))
-            const readerSchema = Type.forSchema(JSON.parse(schemaStringsByType[type].v2)) as any as AvroSchema
+            const readerSchema = Type.forSchema(JSON.parse(schemaStringsByType[type].v2))
             await expect(schemaRegistry.decode(writerBuffer, readerSchema)).resolves.toHaveProperty(
-                'city',
-                'Stockholm'
+              'city',
+              'Stockholm'
             )
           })
 

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -2,13 +2,7 @@ import { Type } from 'avsc'
 import { v4 as uuid } from 'uuid'
 
 import SchemaRegistry from './SchemaRegistry'
-import {
-  ConfluentSubject,
-  ConfluentSchema,
-  SchemaType,
-  AvroConfluentSchema,
-  JsonConfluentSchema,
-} from './@types'
+import { ConfluentSubject, ConfluentSchema, SchemaType } from './@types'
 import API, { SchemaRegistryAPIClient } from './api'
 import { COMPATIBILITY, DEFAULT_API_CLIENT_ID } from './constants'
 import encodedAnotherPersonV2Avro from '../fixtures/avro/encodedAnotherPersonV2'
@@ -366,17 +360,7 @@ describe('SchemaRegistry - new Api', () => {
           await schemaRegistry.decode(buffer)
 
           expect(schemaRegistry.cache.getSchema(registryId)).toBeTruthy()
-        });
-
-        (type == SchemaType.AVRO ? it : it.skip)(
-          'uses reader schema if specified (avro-only)', async () => {
-            const writerBuffer = Buffer.from(await schemaRegistry.encode(registryId, payload))
-            const readerSchema = Type.forSchema(JSON.parse(schemaStringsByType[type].v2))
-            await expect(schemaRegistry.decode(writerBuffer, readerSchema)).resolves.toHaveProperty(
-              'city',
-              'Stockholm'
-            )
-          })
+        })
 
         it('creates a single origin request for a schema cache-miss', async () => {
           const buffer = Buffer.from(await schemaRegistry.encode(registryId, payload))
@@ -606,6 +590,32 @@ describe('SchemaRegistry - new Api', () => {
             expect(error.paths).toEqual([['/fullName']])
           }
         },
+      )
+    })
+  })
+
+  describe('Avro tests', () => {
+    it('uses reader schema if specified (avro-only)', async () => {
+      const subject: ConfluentSubject = {
+        name: [SchemaType.AVRO, 'com.org.domain.fixtures', 'AnotherPerson'].join('.'),
+      }
+      const schema: ConfluentSchema = {
+        type: SchemaType.AVRO,
+        schema: schemaStringsByType[SchemaType.AVRO].v1,
+      }
+      const registryId = (await schemaRegistry.register(schema, { subject: subject.name })).id
+      const writerBuffer = Buffer.from(await schemaRegistry.encode(registryId, payload))
+      const readerSchema = JSON.parse(schemaStringsByType[SchemaType.AVRO].v2)
+
+      await expect(
+        schemaRegistry.decode(writerBuffer, { [SchemaType.AVRO]: { readerSchema } }),
+      ).resolves.toHaveProperty('city', 'Stockholm')
+
+      const registeredReaderSchema = await schemaRegistry.getSchema(registryId)
+      await expect(
+        schemaRegistry.decode(writerBuffer, {
+          [SchemaType.AVRO]: { readerSchema: registeredReaderSchema },
+        }),
       )
     })
   })

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -200,7 +200,7 @@ export default class SchemaRegistry {
     return paths
   }
 
-  public async decode(buffer: Buffer): Promise<any> {
+  public async decode(buffer: Buffer, readerSchema?: AvroSchema): Promise<any> {
     if (!Buffer.isBuffer(buffer)) {
       throw new ConfluentSchemaRegistryArgumentError('Invalid buffer')
     }
@@ -214,8 +214,21 @@ export default class SchemaRegistry {
       )
     }
 
-    const schema = await this.getSchema(registryId)
-    return schema.fromBuffer(payload)
+    const writerSchema = await this.getSchema(registryId)
+    if (readerSchema) {
+      if (readerSchema.equals(writerSchema)){
+        /* Even when schemas are considered equal by `avsc`,
+         * they still aren't interchangeable:
+         * provided `readerSchema` may have different `opts` (e.g. logicalTypes / unionWrap flags)
+         * see https://github.com/mtth/avsc/issues/362 */
+        return readerSchema.fromBuffer(payload)
+      } else {
+        // decode using a resolver from writer type into reader type
+        return readerSchema.fromBuffer(payload, readerSchema.createResolver(writerSchema as AvroSchema))
+      }
+    } else {
+      return writerSchema.fromBuffer(payload)
+    }
   }
 
   public async getRegistryId(subject: string, version: number | string): Promise<number> {

--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -1,3 +1,4 @@
+import { Type } from 'avsc'
 import { Response } from 'mappersmith'
 
 import { encode, MAGIC_BYTE } from './wireEncoder'
@@ -200,7 +201,7 @@ export default class SchemaRegistry {
     return paths
   }
 
-  public async decode(buffer: Buffer, readerSchema?: AvroSchema): Promise<any> {
+  public async decode(buffer: Buffer, readerSchema?: Type): Promise<any> {
     if (!Buffer.isBuffer(buffer)) {
       throw new ConfluentSchemaRegistryArgumentError('Invalid buffer')
     }
@@ -216,7 +217,7 @@ export default class SchemaRegistry {
 
     const writerSchema = await this.getSchema(registryId)
     if (readerSchema) {
-      if (readerSchema.equals(writerSchema)){
+      if (readerSchema.equals(writerSchema as Type)){
         /* Even when schemas are considered equal by `avsc`,
          * they still aren't interchangeable:
          * provided `readerSchema` may have different `opts` (e.g. logicalTypes / unionWrap flags)
@@ -224,7 +225,7 @@ export default class SchemaRegistry {
         return readerSchema.fromBuffer(payload)
       } else {
         // decode using a resolver from writer type into reader type
-        return readerSchema.fromBuffer(payload, readerSchema.createResolver(writerSchema as AvroSchema))
+        return readerSchema.fromBuffer(payload, readerSchema.createResolver(writerSchema as Type))
       }
     } else {
       return writerSchema.fromBuffer(payload)

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,8 +1,10 @@
-import { AvroSchema, Schema } from './@types'
+import { AvroSchema, Schema, SchemaType } from './@types'
+
+type CacheEntry = { type: SchemaType; schema: Schema | AvroSchema }
 
 export default class Cache {
   registryIdBySubject: { [key: string]: number }
-  schemasByRegistryId: { [key: string]: Schema }
+  schemasByRegistryId: { [key: string]: CacheEntry }
 
   constructor() {
     this.registryIdBySubject = {}
@@ -17,10 +19,10 @@ export default class Cache {
     return this.registryIdBySubject[subject]
   }
 
-  getSchema = (registryId: number): Schema | AvroSchema => this.schemasByRegistryId[registryId]
+  getSchema = (registryId: number): CacheEntry | undefined => this.schemasByRegistryId[registryId]
 
-  setSchema = (registryId: number, schema: Schema) => {
-    this.schemasByRegistryId[registryId] = schema
+  setSchema = (registryId: number, type: SchemaType, schema: Schema): CacheEntry => {
+    this.schemasByRegistryId[registryId] = { type, schema }
 
     return this.schemasByRegistryId[registryId]
   }


### PR DESCRIPTION
I can't push to invitae:add-avro-schema-resolution, so I'm opening up this as a continuation of #137 

This changes the proposed interface slightly, as to not pollute non-Avro decoding with a `readerSchema` option that does nothing. It also tries to minimize the amount of types used directly from avsc and instead favors our own Schema types were possible. The reason for this is twofold:

1. Reduce the risk that changes to avsc will affect our users. For example, if avsc released a new version where the `Type` type isn't compatible with the old version, users would be restricted to the version we depend on, even if the actual changes don't affect us.
2. Ensure that you can read a schema using our utilities (`readAvsc` etc) and use those as reader schemas. This means that we internally turn them into avsc `Type` instances when they are used as reader schemas.

This means that the interface becomes:

```ts
let readerSchema = await readAvscAsync('/some/path')
await registry.decode(payload, {
  [SchemaType.AVRO]: {
    readerSchema
  }
})

// Similarly, you should be able to read a schema from the registry and use it as a reader schema
readerSchema = await registry.getSchema(registryId)
await registry.decode(payload, {
  [SchemaType.AVRO]: {
    readerSchema
  }
})
```

This also ensures that the same schema type options from the constructor are used when constructing the `Type` to use for decoding (i.e. the avsc options).

FYI @ivan-klass