### PR TITLE
feat(avro): allow schemas without namespace

### DIFF
--- a/src/AvroHelper.ts
+++ b/src/AvroHelper.ts
@@ -1,10 +1,10 @@
 import {
-  AvroSchema,
-  RawAvroSchema,
   AvroOptions,
+  AvroSchema,
   ConfluentSchema,
-  SchemaHelper,
   ConfluentSubject,
+  RawAvroSchema,
+  SchemaHelper,
 } from './@types'
 import { ConfluentSchemaRegistryArgumentError } from './errors'
 import avro from 'avsc'
@@ -39,14 +39,15 @@ export default class AvroHelper implements SchemaHelper {
   ): ConfluentSubject {
     const rawSchema: RawAvroSchema = this.getRawAvroSchema(schema)
 
-    if (!rawSchema.namespace) {
-      throw new ConfluentSchemaRegistryArgumentError(`Invalid namespace: ${rawSchema.namespace}`)
+    if (rawSchema.namespace) {
+      return {
+        name: [rawSchema.namespace, rawSchema.name].join(separator),
+      }
     }
 
-    const subject: ConfluentSubject = {
-      name: [rawSchema.namespace, rawSchema.name].join(separator),
+    return {
+      name: rawSchema.name,
     }
-    return subject
   }
 
   private isRawAvroSchema(schema: ConfluentSchema | RawAvroSchema): schema is RawAvroSchema {

--- a/src/SchemaRegistry.spec.ts
+++ b/src/SchemaRegistry.spec.ts
@@ -81,14 +81,6 @@ describe('SchemaRegistry - old AVRO api', () => {
       )
     })
 
-    it('throws an error when schema does not have a namespace', async () => {
-      delete Schema.namespace
-      await expect(schemaRegistry.register(Schema)).rejects.toHaveProperty(
-        'message',
-        'Invalid namespace: undefined',
-      )
-    })
-
     it('accepts schema without a namespace when subject is specified', async () => {
       delete Schema.namespace
       const nonNamespaced = readAVSC(path.join(__dirname, '../fixtures/avsc/non_namespaced.avsc'))


### PR DESCRIPTION
Greetings! 
I think it's okay to allow schemas without namespaces.

From Apache Avro spec:
```
Primitive type names have no namespace and their names may not be defined in any namespace.
```
(https://avro.apache.org/docs/current/spec.html)

Also, this PR would allow using [AVSC](https://github.com/mtth/avsc) schema builder, as far as AVSC merging namespaces with name under the hood