### PR TITLE
Handle client-side Mappersmith errors better

### DIFF
--- a/src/api/middleware/errorMiddleware.spec.ts
+++ b/src/api/middleware/errorMiddleware.spec.ts
@@ -44,6 +44,18 @@ describe('ErrorMiddleware', () => {
       ).rejects.toHaveProperty('message', `${middlewareParams.clientId} - ${message}`)
     })
 
+    it('raises an error with a message in case of client-side errors', async () => {
+      const message = 'error message'
+      const response = createResponse(message)
+
+      await expect(
+        executedMiddleware.response(() => Promise.reject(response), undefined),
+      ).rejects.toHaveProperty(
+        'message',
+        `${middlewareParams.clientId} - Error, status 500: ${message}`,
+      )
+    })
+
     it('raise an error with a default message if the error payload is empty', async () => {
       const response = createResponse('')
 

--- a/src/api/middleware/errorMiddleware.ts
+++ b/src/api/middleware/errorMiddleware.ts
@@ -12,7 +12,10 @@ class ResponseError extends Error {
   url: string
 
   constructor(clientName: string, response: ConfluenceResponse) {
-    super(`${clientName} - ${response.data().message || `Error, status ${response.status()}`}`)
+    super(
+      `${clientName} - ${response.data().message ||
+        `Error, status ${response.status()}${response.data() ? `: ${response.data()}` : ''}`}`,
+    )
 
     const request = response.request()
     this.name = this.constructor.name


### PR DESCRIPTION
When mappersmith encounters a client-side error, the response body can be just a string with the error message, rather than an object with a message property. Currently the error message would be unavailable to users of the schema registry, so there would be no way to know what caused the error.