### PR TITLE
prevent mutation of SchemaRegistry options when calling avro.Type.forSchema

### DIFF
--- a/src/AvroHelper.ts
+++ b/src/AvroHelper.ts
@@ -20,8 +20,13 @@ export default class AvroHelper implements SchemaHelper {
     const rawSchema: RawAvroSchema = this.isRawAvroSchema(schema)
       ? schema
       : this.getRawAvroSchema(schema)
+
+    // The `avro.Type.forSchema` will mutate the options object passed. This can cause issues if you calling `getAvroSchema`
+    // for multiple schemas as stale state will bleed between the calls on the mutated options.
+    const optionsCopy = { ...opts }
+
     // @ts-ignore TODO: Fix typings for Schema...
-    const avroSchema: AvroSchema = avro.Type.forSchema(rawSchema, opts)
+    const avroSchema: AvroSchema = avro.Type.forSchema(rawSchema, optionsCopy)
     return avroSchema
   }
 

--- a/src/AvroHelper.ts
+++ b/src/AvroHelper.ts
@@ -23,6 +23,7 @@ export default class AvroHelper implements SchemaHelper {
 
     // The `avro.Type.forSchema` will mutate the options object passed. This can cause issues if you calling `getAvroSchema`
     // for multiple schemas as stale state will bleed between the calls on the mutated options.
+    // This is a work around for: https://github.com/mtth/avsc/issues/312
     const optionsCopy = { ...opts }
 
     // @ts-ignore TODO: Fix typings for Schema...


### PR DESCRIPTION
Fixes: https://github.com/kafkajs/confluent-schema-registry/issues/75

At the moment passing `AVRO` options to the `SchemaRegistry` can cause issues because the underlying `avro.Type.forSchema` call (which receives this options object) mutates the options object. For most cases this doesn't present itself to the user, but if you attempt to register multiple schemas with the same types this throws and error.

```ts
const worksFine = new SchemaRegistry(
    {},
    { AVRO: undefined },
)

const hasIssuesInSomeCases = new SchemaRegistry(
    {},
    { AVRO: {} }, // the inner object will get mutated and leave stale state hanging around that can conflict with future actions
)
```

This PR addresses this by making a copy of the options object before passing it to the mutating `avro.Type.forSchema` call.