### PR TITLE
Remove name check before registration

### DIFF
--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -117,7 +117,6 @@ export default class SchemaRegistry {
 
     const options = await this.updateOptionsWithSchemaReferences(confluentSchema, this.options)
     const schemaInstance = schemaFromConfluentSchema(confluentSchema, options)
-    helper.validate(schemaInstance)
     let isFirstTimeRegistration = false
     let subject: ConfluentSubject
     if (userOpts?.subject) {


### PR DESCRIPTION
This `helper.validate` code just checks if the schema has a "name". However, when registering primitive types, since they don't have a name, registration fails because of this check. Please remove this code if it's not used for anything else (I checked, it's not), and let the server validate the schema.
