### PR TITLE
Adding AccessTokenMiddleware to support bearer token authentication

### DIFF
--- a/src/SchemaRegistry.ts
+++ b/src/SchemaRegistry.ts
@@ -62,10 +62,10 @@ export default class SchemaRegistry {
   public cache: Cache
 
   constructor(
-    { auth, clientId, host, retry, agent }: SchemaRegistryAPIClientArgs,
+    { auth, accessTokenParams, clientId, host, retry, agent }: SchemaRegistryAPIClientArgs,
     options?: SchemaRegistryAPIClientOptions,
   ) {
-    this.api = API({ auth, clientId, host, retry, agent })
+    this.api = API({ auth, accessTokenParams, clientId, host, retry, agent })
     this.cache = new Cache()
     this.options = options
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,12 +1,13 @@
 import { Agent } from 'http'
 import forge, { Authorization, Client, Options, GatewayConfiguration } from 'mappersmith'
 import RetryMiddleware, { RetryMiddlewareOptions } from 'mappersmith/middleware/retry/v2'
-import BasicAuthMiddleware from 'mappersmith/middleware/basic-auth'
 
 import { DEFAULT_API_CLIENT_ID } from '../constants'
 import errorMiddleware from './middleware/errorMiddleware'
 import confluentEncoder from './middleware/confluentEncoderMiddleware'
 import userAgentMiddleware from './middleware/userAgent'
+import AccessTokenMiddleware, { AccessTokenParams } from './middleware//AccessTokenMiddleware'
+import BasicAuthMiddleware from 'mappersmith/middleware/basic-auth'
 
 const DEFAULT_RETRY = {
   maxRetryTimeInSecs: 5,
@@ -19,6 +20,7 @@ const DEFAULT_RETRY = {
 export interface SchemaRegistryAPIClientArgs {
   host: string
   auth?: Authorization
+  accessTokenParams?: AccessTokenParams
   clientId?: string
   retry?: Partial<RetryMiddlewareOptions>
   /** HTTP Agent that will be passed to underlying API calls */
@@ -44,6 +46,7 @@ export type SchemaRegistryAPIClient = Client<{
 
 export default ({
   auth,
+  accessTokenParams,
   clientId: userClientId,
   host,
   retry = {},
@@ -61,6 +64,7 @@ export default ({
       RetryMiddleware(Object.assign(DEFAULT_RETRY, retry)),
       errorMiddleware,
       ...(auth ? [BasicAuthMiddleware(auth)] : []),
+      ...(accessTokenParams ? [AccessTokenMiddleware(accessTokenParams)] : []),
     ],
     resources: {
       Schema: {

--- a/src/api/middleware/AccessTokenMiddleware.ts
+++ b/src/api/middleware/AccessTokenMiddleware.ts
@@ -1,0 +1,49 @@
+import { Middleware } from 'mappersmith'
+let accessToken: string | null = null
+let expiredAt: number | null = null
+
+export interface AccessTokenParams {
+  readonly clientCredentials: {
+    readonly clientId: string
+    readonly clientSecret: string
+  }
+  readonly authHost: string
+  refreshToken(authHost: string, clientId: string, clientSecret: string): Promise<string>
+  refreshThresholdMs?: number
+}
+
+export default (params: AccessTokenParams): Middleware =>
+  function AccessTokenMiddleware() {
+    return {
+      async request(request) {
+        return Promise.resolve(accessToken)
+          .then(async token => {
+            if (token && (!expiredAt || expiredAt > Date.now())) {
+              return token
+            }
+            return await params.refreshToken(
+              params.authHost,
+              params.clientCredentials.clientId,
+              params.clientCredentials.clientSecret,
+            )
+          })
+          .then(token => {
+            accessToken = token
+            expiredAt = params.refreshThresholdMs ? Date.now() + params.refreshThresholdMs : null
+            return request.enhance({
+              headers: { Authorization: token },
+            })
+          })
+      },
+      async response(next, renew) {
+        return next().catch(response => {
+          // token expired
+          if (response.status === 401) {
+            accessToken = null
+            return renew()
+          }
+          return next()
+        })
+      },
+    }
+  }


### PR DESCRIPTION
# Why?
A few months back I created an issue https://github.com/kafkajs/confluent-schema-registry/issues/239, that we need to use Oauth with bearer authentication in our project. I haven't heard any responses yet from the issue I created. So we went ahead and implemented ourself.

# What
In this MR, I added `renew` middleware from mappersmith project https://github.com/tulios/mappersmith#-renew. This will help to renew the token if it's expired. I also added a way that we can set the `refreshThresholdMs` to auto refresh the token if it's expired by our timer. 

#  Example

```
// We have a refreshToken function to get the token from our service
export async function refreshToken(authHost: string, clientId: string, clientSecret: string): Promise<string> {
  /// creating your data and axiosConfig
  const response = await axios.post<PostObject>(authHost, data, axiosConfig)
  return `Bearer ${response.data.access_token}`
}

// And add it into the params:
new SchemaRegistry({
      host: host,
      accessTokenParams: {
        clientCredentials: {
          clientId: '',
          clientSecret: ''
        },
        authHost: '',
        refreshThresholdMs: 10000,
        refreshToken: refreshToken
      }
    })
```



