### PR TITLE
Support for Confluent's Ksql - addition of messageIndexes in the wire format

### DIFF
--- a/src/wireDecoder.ts
+++ b/src/wireDecoder.ts
@@ -1,5 +1,6 @@
 export default (buffer: Buffer) => ({
   magicByte: buffer.slice(0, 1),
   registryId: buffer.slice(1, 5).readInt32BE(0),
-  payload: buffer.slice(5, buffer.length),
+  messageIndexes: buffer.slice(5, 6),
+  payload: buffer.slice(6, buffer.length),
 })

--- a/src/wireDecoder.ts
+++ b/src/wireDecoder.ts
@@ -1,6 +1,14 @@
-export default (buffer: Buffer) => ({
-  magicByte: buffer.slice(0, 1),
-  registryId: buffer.slice(1, 5).readInt32BE(0),
-  messageIndexes: buffer.slice(5, 6),
-  payload: buffer.slice(6, buffer.length),
-})
+export default (buffer: Buffer) => {
+  const magicByte = buffer.slice(0, 1)
+  const registryId = buffer.slice(1, 5).readInt32BE(0)
+  const messageIndexesLength = buffer.slice(5, 9).readInt32BE(0)
+  const messageIndexes = buffer.slice(9, 9 + messageIndexesLength)
+  const payload = buffer.slice(9 + messageIndexesLength)
+
+  return {
+    magicByte,
+    registryId,
+    messageIndexes,
+    payload,
+  }
+}

--- a/src/wireEncoder.ts
+++ b/src/wireEncoder.ts
@@ -2,9 +2,9 @@ const DEFAULT_OFFSET = 0
 
 export const MAGIC_BYTE = Buffer.alloc(1)
 
-export const encode = (registryId: number, payload: Buffer) => {
+export const encode = (registryId: number, payload: Buffer, messageIndexes: number[] = [0]) => {
   const registryIdBuffer = Buffer.alloc(4)
   registryIdBuffer.writeInt32BE(registryId, DEFAULT_OFFSET)
 
-  return Buffer.concat([MAGIC_BYTE, registryIdBuffer, payload])
+  return Buffer.concat([MAGIC_BYTE, registryIdBuffer, Buffer.from(messageIndexes), payload])
 }

--- a/src/wireEncoder.ts
+++ b/src/wireEncoder.ts
@@ -6,5 +6,15 @@ export const encode = (registryId: number, payload: Buffer, messageIndexes: numb
   const registryIdBuffer = Buffer.alloc(4)
   registryIdBuffer.writeInt32BE(registryId, DEFAULT_OFFSET)
 
-  return Buffer.concat([MAGIC_BYTE, registryIdBuffer, Buffer.from(messageIndexes), payload])
+  const messageIndexesBuffer = Buffer.from(messageIndexes)
+  const messageIndexesLength = Buffer.alloc(4)
+  messageIndexesLength.writeInt32BE(messageIndexesBuffer.length, DEFAULT_OFFSET)
+
+  return Buffer.concat([
+    MAGIC_BYTE,
+    registryIdBuffer,
+    messageIndexesLength,
+    messageIndexesBuffer,
+    payload,
+  ])
 }


### PR DESCRIPTION
## Summary:
This PR request is aimed at addressing an issue with the encoding method in the kafkajs module. The original encoding method did not allow Confluent's ksql client, written in Java, to successfully decode messages if they were using a **protobuf** schema. This was due to the absence of messageIndexes in the wire format. The relevant documentation can be found [here](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format). 

## Main Changes:
The primary change in this PR is the addition of the `messageIndexes` in the wire format in the encoding function. It also updates the decoding function to ensure that the new change will not affect its original behavior.

```
export const encode = (registryId: number, payload: Buffer, messageIndexes: number[] = [0]) => {
  const registryIdBuffer = Buffer.alloc(4)
  registryIdBuffer.writeInt32BE(registryId, DEFAULT_OFFSET)

  return Buffer.concat([MAGIC_BYTE, registryIdBuffer, Buffer.from(messageIndexes), payload]) --> main change
}
```
The `messageIndexes` are now being sliced from the buffer and set as a separate parameter. This modification ensures that the encoded message now includes the messageIndexes in the wire format, thereby allowing the Confluent's ksql Java client to successfully decode it.

For simplicity, the default value is `[0]`. As stated in Confluent's [documentation](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format), "most of the time the actual message type will be just the first message type (which is the array [0])". 

## Impacts:
This update should improve the compatibility of any encoded messages with Confluent's ksql client. Users leveraging protobuf schema should now be able to decode messages successfully via ksql. This update should not affect any existing functionalities and is expected to enhance the overall usability and user experience of our service.