### PR TITLE
Add PSA to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `@kafkajs/confluent-schema-registry` is a library that makes it easier to interact with the Confluent schema registry, it provides convenient methods to encode, decode and register new schemas using the Apache Avro serialization format and Confluent's [wire format](https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format).
 
+Note that this is an unofficial client that is maintained based on the [specific needs of the primary maintainer, as well as the contributions of the community](https://github.com/kafkajs/confluent-schema-registry/issues/215#issuecomment-1261967603). For example, at the time of this writing, this package is **NOT** fully compliant with Confluent's [Protobuf serialization spec](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format). This means that this package will only work when it used as *both* the serializer *and* deserializer of schema registry messages. So, for example, if you're serializing Protobuf messages with [Confluent's Kafka Golang client](https://github.com/confluentinc/confluent-kafka-go), this package will not correctly deserialize those messages (and vice-versa). See https://github.com/kafkajs/confluent-schema-registry/issues/152 for more detail on this.
+
 [![Build Status](https://dev.azure.com/tulios/ConfluentSchemaRegistry/_apis/build/status/kafkajs.confluent-schema-registry?branchName=master)](https://dev.azure.com/tulios/ConfluentSchemaRegistry/_build/latest?definitionId=3&branchName=master)
 
 ## Getting started


### PR DESCRIPTION
My company recently started using this package for our NodeJS clients when integrating Confluent's Schema Registry into our infrastructure. We recently ran into issues with Protobuf messages serialized by Confluent's Go client that revealed incompatibilities with the wire format expected by this library. After this discovery I realized this was a [known issue](https://github.com/kafkajs/confluent-schema-registry/issues/152).

As this is the most prominent JS client for Confluent's schema registry, I believe it was easy for us to misinterpret this as a fully compatible client. I'm currently working to rectify this on our end, and hope to contribute to this package to fix the issue for others across the board. In the meantime, I've updated the README with the details I found as I was coming to understand these things, as they are crucial for anyone looking to integrate this into their infrastructure.