### PR TITLE
Feat: Enhance error middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ trash
 
 \.vscode/
 \.vs/
+\.idea/
 
 # confluent-schema-registry
 #

--- a/src/api/middleware/errorMiddleware.ts
+++ b/src/api/middleware/errorMiddleware.ts
@@ -12,9 +12,15 @@ class ResponseError extends Error {
   url: string
 
   constructor(clientName: string, response: ConfluenceResponse) {
+    const responseData = response.data()
+    const isResponseDataAnObject = typeof responseData === 'object'
+    const responseDataString = isResponseDataAnObject ? JSON.stringify(responseData) : responseData
+
     super(
-      `${clientName} - ${response.data().message ||
-        `Error, status ${response.status()}${response.data() ? `: ${response.data()}` : ''}`}`,
+      `${clientName} - ${responseData.message ||
+        `Error, status ${response.status()}${
+          responseDataString ? `: ${responseDataString}` : ''
+        }`}`,
     )
 
     const request = response.request()


### PR DESCRIPTION
I've encountered an improvement in the error middleware since it's prompting this message:

`ResponseError: Confluent_Schema_Registry - Error, status 500: [object Object]
    at /adjustment-service/node_modules/@kafkajs/confluent-schema-registry/dist/api/middleware/errorMiddleware.js:17:37
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  status: 500,
  unauthorized: false,
  ...}`
  
  The improvement comes in [Object object], I think it should be improved using `JSON.stringify`