### PR TITLE
Upgrading minimum mappersmith version to 2.43.0 to avoid potential CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kafkajs/confluent-schema-registry",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "description": "ConfluentSchemaRegistry is a library that makes it easier to interact with the Confluent schema registry, it provides convenient methods to encode, decode and register new schemas using the Apache Avro serialization format.",
   "keywords": [
@@ -25,7 +25,7 @@
   "dependencies": {
     "ajv": "^7.1.0",
     "avsc": ">= 5.4.13 < 6",
-    "mappersmith": ">= 2.30.1 < 3",
+    "mappersmith": ">= 2.43.0 < 3",
     "protobufjs": "^6.11.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,10 +2838,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-"mappersmith@>= 2.30.1 < 3":
-  version "2.32.1"
-  resolved "https://registry.yarnpkg.com/mappersmith/-/mappersmith-2.32.1.tgz#e5c82cf53684777940516a63590c8b7d53c747c5"
-  integrity sha512-FlXIvDrYU3Jrkfr3Y0M1v6ZOCe6GdHWev8Jn4OFCa9057JaO6SC40Z0ivN2lpZLICYh0jbnZ83DAS7GNQAZPsg==
+"mappersmith@>= 2.43.0 < 3":
+  version "2.43.4"
+  resolved "https://registry.yarnpkg.com/mappersmith/-/mappersmith-2.43.4.tgz#8e00d82b95d9bfae6a5b519d93f2c0b0394fce20"
+  integrity sha512-IyUw53aE3/SPH3eOkqSuD+Hcstpcl4dpxDDgZsPz65R2SlOikq0VHxo3kMPzUVvw7cCHunTmlpNXl5n/KzPcpg==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Upgrading minimum mappersmith version to 2.43.0 to avoid potential CVE

Affected versions of the mappersmith library are vulnerable to memory leaks when using http(s) agent with keep-alive=true. The tcp socket events register once per API call, which may lead to excessive memory use.

From 2.28 to 2.42