### PR TITLE
Update SchemaRegistry export to better support esm imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { default as SchemaRegistry, DecodeOptions } from './SchemaRegistry'
+import { default as SchemaRegistry, DecodeOptions } from './SchemaRegistry'
+export { SchemaRegistry, DecodeOptions }
 export * from './utils'
 export { SchemaType } from './@types'
 export { COMPATIBILITY } from './constants'


### PR DESCRIPTION
## The issue

With the latest upgrade of this package we discovered some issues with importing the module in our project that uses pure ESM in production. It failed saying `SyntaxError: Named export 'SchemaRegistry' not found.`

After some git bisect I've been able to narrrow it down to an upgrade of Typescript in commit `8f47644`. I _think_ Typescript have updated it's build output in an effort to be more spec compliant. At least this is my guess.

The line that causes the issue is in `src/index.ts`: `export { default as SchemaRegistry, DecodeOptions } from './SchemaRegistry'`. That way of directly exporting the default value seems to not work as intended and node's esm/commonjs interop can't really handle the TS output.

You can validate this by yourself by executing the following in a `.mjs` file in the repo (not on this branch):

```js
// test.mjs
import * as csr from './dist/index.js'
console.log(csr)
```

With the _current_ version you will get a log output similar to the one below:

```sh
[Module: null prototype] {
  COMPATIBILITY: { ... },
  SchemaType: { ... },
  __esModule: true,
  avdlToAVSC: [Function: avdlToAVSC],
  avdlToAVSCAsync: [AsyncFunction: avdlToAVSCAsync],
  readAVSC: [Function: readAVSC],
  readAVSCAsync: [AsyncFunction: readAVSCAsync]
  default: {
    SchemaRegistry: [Getter],
    SchemaType: [Getter],
    COMPATIBILITY: [Getter],
    avdlToAVSC: [Getter],
    avdlToAVSCAsync: [Getter],
    readAVSC: [Getter],
    readAVSCAsync: [Getter]
  },
}
```

As you can see `SchemaRegistry` is only available on the `default` object. This means it can currently only be imported like this:

```js
import csr from '@kafkajs/confluent-schema-registry'
console.log(csr.SchemaRegistry)
```

## The fix

This PR fixes the issue above by _first_ importing the SchemaRegistry class _before_ exporting it. This means nodejs's csj/esm interop will be able to detect the export properly and the module can be imported as before. This fix should not be a breaking change and can be considered a bigfix or patch.

## The future

In the future I think it would be great to either default to pure esm in this module, or do set up some kind of dual export with the help of e.g. [tshy](https://github.com/isaacs/tshy).

