### PR TITLE
update to return full value from schema regsitry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [3.3.2] - 2025-01-29
+## Fixed
+Json schema validation return, adds the error message
+Fixes docker compose dependency
+
+### Added
+
 ## [3.3.0] - 2022-10-04
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       KAFKA_BROKER_ID: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     depends_on:
-      - zooKeeper
+     zooKeeper:
+       condition: service_healthy
     image: 'confluentinc/cp-kafka:5.5.3'
     ports:
       - '9092:9092'
@@ -40,7 +41,8 @@ services:
     ports:
       - '8982:8081'
     depends_on:
-      - kafka
+      kafka: 
+        condition: service_healthy
     healthcheck:
       test:  "curl --output /dev/null --silent --head --fail http://localhost:8081/subjects"
       interval: 30s

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kafkajs/confluent-schema-registry",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "main": "dist/index.js",
   "description": "ConfluentSchemaRegistry is a library that makes it easier to interact with the Confluent schema registry, it provides convenient methods to encode, decode and register new schemas using the Apache Avro serialization format.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kafkajs/confluent-schema-registry",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "main": "dist/index.js",
   "description": "ConfluentSchemaRegistry is a library that makes it easier to interact with the Confluent schema registry, it provides convenient methods to encode, decode and register new schemas using the Apache Avro serialization format.",
   "keywords": [

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -30,6 +30,7 @@ export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & {
       }
     | Ajv
   referencedSchemas?: JsonConfluentSchema[]
+  includeErrorPaths?: boolean;
 }
 export type ProtoOptions = { messageName?: string; referencedSchemas?: ProtoConfluentSchema[] }
 

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -30,7 +30,7 @@ export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & {
       }
     | Ajv
   referencedSchemas?: JsonConfluentSchema[]
-  includeErrorPaths?: boolean;
+  includeErrorPaths?: boolean
 }
 export type ProtoOptions = { messageName?: string; referencedSchemas?: ProtoConfluentSchema[] }
 

--- a/src/@types.ts
+++ b/src/@types.ts
@@ -30,7 +30,7 @@ export type JsonOptions = ConstructorParameters<typeof Ajv>[0] & {
       }
     | Ajv
   referencedSchemas?: JsonConfluentSchema[]
-  includeErrorPaths?: boolean
+  detailedErrorPaths?: boolean
 }
 export type ProtoOptions = { messageName?: string; referencedSchemas?: ProtoConfluentSchema[] }
 

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -10,7 +10,6 @@ interface BaseAjvValidationError {
 interface OldAjvValidationError extends BaseAjvValidationError {
   dataPath: string
   instancePath?: string
-
 }
 interface NewAjvValidationError extends BaseAjvValidationError {
   instancePath: string
@@ -43,13 +42,15 @@ export default class JsonSchema implements Schema {
   }
 
   private validatePayload(payload: any) {
-    const paths: any[] = [];
+    const paths: any[] = []
 
-    if (!this.isValid(payload, {
-      errorHook: (path, message) => {
-        paths.push({ path, message });
-      }
-    })) {
+    if (
+      !this.isValid(payload, {
+        errorHook: (path, message) => {
+          paths.push({ path, message })
+        },
+      })
+    ) {
       throw new ConfluentSchemaRegistryValidationError('invalid payload', paths)
     }
   }
@@ -69,12 +70,11 @@ export default class JsonSchema implements Schema {
     payload: object,
     opts?: { errorHook: (path: Array<string>, value: any, type?: any) => void },
   ): boolean {
-
     if (!this.validate(payload)) {
       if (opts?.errorHook) {
         for (const err of this.validate.errors as AjvValidationError[]) {
-          const path = this.isOldAjvValidationError(err) ? err.dataPath : err.instancePath;
-          opts.errorHook([path], err.message ?? err.data, err.schema);
+          const path = this.isOldAjvValidationError(err) ? err.dataPath : err.instancePath
+          opts.errorHook([path], err.message ?? err.data, err.schema)
         }
         return false
       }

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -23,11 +23,11 @@ export interface ValidateFunction {
 }
 export default class JsonSchema implements Schema {
   private validate: ValidateFunction
-  private includeErrorPaths: boolean;
+  private includeErrorPaths: boolean
 
   constructor(schema: JsonConfluentSchema, opts?: JsonOptions) {
     this.validate = this.getJsonSchema(schema, opts)
-    this.includeErrorPaths = opts?.includeErrorPaths ? opts?.includeErrorPaths: false;
+    this.includeErrorPaths = opts?.includeErrorPaths ? opts?.includeErrorPaths : false
   }
 
   private getJsonSchema(schema: JsonConfluentSchema, opts?: JsonOptions) {
@@ -49,12 +49,11 @@ export default class JsonSchema implements Schema {
     if (
       !this.isValid(payload, {
         errorHook: (path, message) => {
-          if(this.includeErrorPaths) {
+          if (this.includeErrorPaths) {
             paths.push({ path, message })
           } else {
-            paths.push(path);
+            paths.push(path)
           }
-         
         },
       })
     ) {

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -23,11 +23,11 @@ export interface ValidateFunction {
 }
 export default class JsonSchema implements Schema {
   private validate: ValidateFunction
-  private includeErrorPaths: boolean
+  private detailedErrorPaths: boolean
 
   constructor(schema: JsonConfluentSchema, opts?: JsonOptions) {
     this.validate = this.getJsonSchema(schema, opts)
-    this.includeErrorPaths = opts?.includeErrorPaths ? opts?.includeErrorPaths : false
+    this.detailedErrorPaths = opts?.detailedErrorPaths ? opts?.detailedErrorPaths : false
   }
 
   private getJsonSchema(schema: JsonConfluentSchema, opts?: JsonOptions) {
@@ -49,7 +49,7 @@ export default class JsonSchema implements Schema {
     if (
       !this.isValid(payload, {
         errorHook: (path, message) => {
-          if (this.includeErrorPaths) {
+          if (this.detailedErrorPaths) {
             paths.push({ path, message })
           } else {
             paths.push(path)

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -45,15 +45,16 @@ export default class JsonSchema implements Schema {
 
   private validatePayload(payload: any) {
     const paths: any[] = []
-    let errorHandler = (path, message) => {
-      paths.push(path)
-    }
-    if (this.includeErrorPaths) {
-      errorHandler = (path, message) => paths.push({ path, message })
-    }
+
     if (
       !this.isValid(payload, {
-        errorHook: errorHandler,
+        errorHook: (path, message) => {
+          if (this.includeErrorPaths) {
+            paths.push({ path, message })
+          } else {
+            paths.push(path)
+          }
+        },
       })
     ) {
       throw new ConfluentSchemaRegistryValidationError('invalid payload', paths)

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -45,16 +45,15 @@ export default class JsonSchema implements Schema {
 
   private validatePayload(payload: any) {
     const paths: any[] = []
-
+    let errorHandler = (path, message) => {
+      paths.push(path)
+    }
+    if (this.includeErrorPaths) {
+      errorHandler = (path, message) => paths.push({ path, message })
+    }
     if (
       !this.isValid(payload, {
-        errorHook: (path, message) => {
-          if (this.includeErrorPaths) {
-            paths.push({ path, message })
-          } else {
-            paths.push(path)
-          }
-        },
+        errorHook: errorHandler,
       })
     ) {
       throw new ConfluentSchemaRegistryValidationError('invalid payload', paths)

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -23,9 +23,11 @@ export interface ValidateFunction {
 }
 export default class JsonSchema implements Schema {
   private validate: ValidateFunction
+  private includeErrorPaths: boolean;
 
   constructor(schema: JsonConfluentSchema, opts?: JsonOptions) {
     this.validate = this.getJsonSchema(schema, opts)
+    this.includeErrorPaths = opts?.includeErrorPaths ? opts?.includeErrorPaths: false;
   }
 
   private getJsonSchema(schema: JsonConfluentSchema, opts?: JsonOptions) {
@@ -47,7 +49,12 @@ export default class JsonSchema implements Schema {
     if (
       !this.isValid(payload, {
         errorHook: (path, message) => {
-          paths.push({ path, message })
+          if(this.includeErrorPaths) {
+            paths.push({ path, message })
+          } else {
+            paths.push(path);
+          }
+         
         },
       })
     ) {

--- a/src/SchemaRegistry.json.spec.ts
+++ b/src/SchemaRegistry.json.spec.ts
@@ -105,6 +105,7 @@ describe('SchemaRegistry', () => {
     const options = {
       [SchemaType.JSON]: {
         allErrors: true,
+        includeErrorPaths: true
       },
     }
     api = API(schemaRegistryAPIClientArgs)

--- a/src/SchemaRegistry.json.spec.ts
+++ b/src/SchemaRegistry.json.spec.ts
@@ -105,7 +105,7 @@ describe('SchemaRegistry', () => {
     const options = {
       [SchemaType.JSON]: {
         allErrors: true,
-        includeErrorPaths: true
+        includeErrorPaths: true,
       },
     }
     api = API(schemaRegistryAPIClientArgs)

--- a/src/SchemaRegistry.json.spec.ts
+++ b/src/SchemaRegistry.json.spec.ts
@@ -104,8 +104,8 @@ describe('SchemaRegistry', () => {
   beforeEach(async () => {
     const options = {
       [SchemaType.JSON]: {
-        allErrors: true
-      }
+        allErrors: true,
+      },
     }
     api = API(schemaRegistryAPIClientArgs)
     schemaRegistry = new SchemaRegistry(schemaRegistryArgs, options)
@@ -114,7 +114,6 @@ describe('SchemaRegistry', () => {
   describe('when register', () => {
     describe('when no reference', () => {
       beforeEach(async () => {
-
         registeredSchema = await schemaRegistry.register(TestSchemas.ThirdLevelSchema, {
           subject: 'JSON:ThirdLevel',
         })
@@ -169,15 +168,14 @@ describe('SchemaRegistry', () => {
 
         expect(resultObj).toEqual(obj)
       })
-     
+
       it('should return error message', async () => {
-        const obj = { id2a: "sdfsdfsdf", level2a: 1 };
+        const obj = { id2a: 'sdfsdfsdf', level2a: 1 }
         try {
           await schemaRegistry.encode(registeredSchema.id, obj)
         } catch (ex) {
-
-          expect(ex.paths[0].message).toBeDefined();
-          expect(ex.paths[0].message).toEqual("should be number");
+          expect(ex.paths[0].message).toBeDefined()
+          expect(ex.paths[0].message).toEqual('should be number')
         }
       })
     })
@@ -250,7 +248,7 @@ describe('SchemaRegistry', () => {
         registeredSchema = await schemaRegistry.register(TestSchemas.ThirdLevelSchema, {
           subject: 'JSON:ThirdLevel',
         })
-          ; ({ schema } = await schemaRegistry['_getSchema'](registeredSchema.id))
+        ;({ schema } = await schemaRegistry['_getSchema'](registeredSchema.id))
       })
 
       it('should be able to encode/decode', async () => {
@@ -272,7 +270,7 @@ describe('SchemaRegistry', () => {
         registeredSchema = await schemaRegistry.register(TestSchemas.SecondLevelASchema, {
           subject: 'JSON:SecondLevelA',
         })
-          ; ({ schema } = await schemaRegistry['_getSchema'](registeredSchema.id))
+        ;({ schema } = await schemaRegistry['_getSchema'](registeredSchema.id))
       })
 
       it('should be able to encode/decode', async () => {
@@ -312,7 +310,7 @@ describe('SchemaRegistry', () => {
         registeredSchema = await schemaRegistry.register(TestSchemas.FirstLevelSchema, {
           subject: 'JSON:FirstLevel',
         })
-          ; ({ schema } = await schemaRegistry['_getSchema'](registeredSchema.id))
+        ;({ schema } = await schemaRegistry['_getSchema'](registeredSchema.id))
       })
 
       it('should be able to encode/decode', async () => {

--- a/src/SchemaRegistry.json.spec.ts
+++ b/src/SchemaRegistry.json.spec.ts
@@ -105,7 +105,7 @@ describe('SchemaRegistry', () => {
     const options = {
       [SchemaType.JSON]: {
         allErrors: true,
-        includeErrorPaths: true,
+        detailedErrorPaths: true,
       },
     }
     api = API(schemaRegistryAPIClientArgs)

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -570,7 +570,7 @@ describe('SchemaRegistry - new Api', () => {
         async (_, ajvInstance) => {
           expect.assertions(3)
           const registry = new SchemaRegistry(schemaRegistryArgs, {
-            [SchemaType.JSON]: { ajvInstance, includeErrorPaths: true },
+            [SchemaType.JSON]: { ajvInstance, detailedErrorPaths: true },
           })
           const subject: ConfluentSubject = {
             name: [SchemaType.JSON, 'com.org.domain.fixtures', 'AnotherPerson'].join('.'),

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -587,7 +587,7 @@ describe('SchemaRegistry - new Api', () => {
           } catch (error) {
             expect(error).toBeInstanceOf(ConfluentSchemaRegistryValidationError)
             expect(error.message).toEqual('invalid payload')
-            expect(error.paths).toEqual([['/fullName']])
+            expect(error.paths[0].path).toEqual(['/fullName'])
           }
         },
       )

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -570,7 +570,7 @@ describe('SchemaRegistry - new Api', () => {
         async (_, ajvInstance) => {
           expect.assertions(3)
           const registry = new SchemaRegistry(schemaRegistryArgs, {
-            [SchemaType.JSON]: { ajvInstance, includeErrorPaths: true }, 
+            [SchemaType.JSON]: { ajvInstance, includeErrorPaths: true },
           })
           const subject: ConfluentSubject = {
             name: [SchemaType.JSON, 'com.org.domain.fixtures', 'AnotherPerson'].join('.'),

--- a/src/SchemaRegistry.newApi.spec.ts
+++ b/src/SchemaRegistry.newApi.spec.ts
@@ -570,7 +570,7 @@ describe('SchemaRegistry - new Api', () => {
         async (_, ajvInstance) => {
           expect.assertions(3)
           const registry = new SchemaRegistry(schemaRegistryArgs, {
-            [SchemaType.JSON]: { ajvInstance },
+            [SchemaType.JSON]: { ajvInstance, includeErrorPaths: true }, 
           })
           const subject: ConfluentSubject = {
             name: [SchemaType.JSON, 'com.org.domain.fixtures', 'AnotherPerson'].join('.'),
@@ -583,7 +583,7 @@ describe('SchemaRegistry - new Api', () => {
           const { id: schemaId } = await registry.register(schema, { subject: subject.name })
 
           try {
-            await schemaRegistry.encode(schemaId, { fullName: true })
+            await registry.encode(schemaId, { fullName: true })
           } catch (error) {
             expect(error).toBeInstanceOf(ConfluentSchemaRegistryValidationError)
             expect(error.message).toEqual('invalid payload')


### PR DESCRIPTION
Currently, the errors from json schema validations only return the paths as an array
- "/field1"
- "/field2"
however it does not actually return the error itself in order to resolve the issues. 

This pr will change the return value from 
- "/field1"
- "/field2"

to
- path: "/field1"
   message: "should be number"
- path: "/field2"
   message: "should be object"

Additionaly, the docker compose does not properly wait for the health check of the dependant services. 
This PR resolves that in order to make development and getting started an easier process