### PR TITLE
Fix : Since at least protobufjs 7.5.2, double dot is not accepted in path lookup

### DIFF
--- a/src/ProtoSchema.ts
+++ b/src/ProtoSchema.ts
@@ -37,7 +37,7 @@ export default class ProtoSchema implements Schema {
     const root = parsedMessage.root
     const pkg = parsedMessage.package
     const name = opts && opts.messageName ? opts.messageName : this.getNestedTypeName(root.nested)
-    return `${pkg ? pkg + '.' : ''}.${name}`
+    return `${pkg ? pkg : ''}.${name}`
   }
 
   private trimStart(buffer: Buffer): Buffer {


### PR DESCRIPTION
Hi, 
I linked the issue with full explanations https://github.com/kafkajs/confluent-schema-registry/issues/299

In this PR I remove the double dot in path lookup when a package is set that was working in` protobufjs@6.11.3` up until  `protobufjs@7.4.0`but not in recent `protobufjs@7.5.2`